### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,82 @@
+# --------------------------------------------
+# CITATION file created with {cffr} R package
+# See also: https://docs.ropensci.org/cffr/
+# --------------------------------------------
+ 
+cff-version: 1.2.0
+message: 'To cite package "CNVRanger" in publications use:'
+type: software
+license: Artistic-2.0
+title: 'CNVRanger: Summarization and expression/phenotype association of CNV ranges'
+version: 1.29.1
+doi: 10.1093/bioinformatics/btz632
+abstract: The CNVRanger package implements a comprehensive tool suite for CNV analysis.
+  This includes functionality for summarizing individual CNV calls across a population,
+  assessing overlap with functional genomic regions, and association analysis with
+  gene expression and quantitative phenotypes.
+authors:
+- family-names: Geistlinger
+  given-names: Ludwig
+  email: ludwig.geistlinger@gmail.com
+  orcid: https://orcid.org/0000-0002-2495-5464
+- family-names: Silva
+  given-names: Vinicius Henrique
+  name-particle: da
+preferred-citation:
+  type: article
+  title: 'CNVRanger: association analysis of CNVs with gene expression and quantitative
+    phenotypes'
+  authors:
+  - family-names: Silva
+    given-names: Vinicius Henrique da
+  - family-names: Ramos
+    given-names: Marcel
+  - family-names: Groenen
+    given-names: Martien
+  - family-names: Crooijmans
+    given-names: Richard
+  - family-names: Johansson
+    given-names: Anna
+  - family-names: Regitano
+    given-names: Luciana
+  - family-names: Coutinho
+    given-names: Luiz
+  - family-names: Zimmer
+    given-names: Ralf
+  - family-names: Waldron
+    given-names: Levi
+  - family-names: Geistlinger
+    given-names: Ludwig
+    email: ludwig.geistlinger@gmail.com
+    orcid: https://orcid.org/0000-0002-2495-5464
+  year: '2020'
+  journal: Bioinformatics
+  volume: 36(3)
+  doi: 10.1093/bioinformatics/btz632
+  start: 972-73
+repository: https://bioconductor.org/
+repository-code: https://github.com/waldronlab/CNVRanger
+url: https://github.com/waldronlab/CNVRanger
+date-released: '2025-05-08'
+contact:
+- family-names: Geistlinger
+  given-names: Ludwig
+  email: ludwig.geistlinger@gmail.com
+  orcid: https://orcid.org/0000-0002-2495-5464
+keywords:
+- bioconductor-package
+- u24ca289073
+references:
+- type: manual
+  title: 'CNVRanger: Summarization and expression/phenotype association of CNV ranges'
+  authors:
+  - family-names: Geistlinger
+    given-names: Ludwig
+    email: ludwig.geistlinger@gmail.com
+    orcid: https://orcid.org/0000-0002-2495-5464
+  - family-names: Silva
+    given-names: Vinicius Henrique
+    name-particle: da
+  year: '2025'
+  notes: R package version 1.29.1
+


### PR DESCRIPTION
This automated PR adds or updates `CITATION.cff` using the
[cffr](https://docs.ropensci.org/cffr/) R package (`cffr::cff_write()`).
Citation metadata is derived from the package `DESCRIPTION`, and the
auto-citation is also included as a `references` entry.

## Changes
- **Added / updated** `CITATION.cff` – generated by `cffr::cff_write()` with
  the auto-citation included under `references`

## How citations are handled
- If `inst/CITATION` exists in the repository it is automatically used by
  `cff_write()` as the `preferred-citation` in `CITATION.cff`.
- Otherwise, citation metadata is derived solely from `DESCRIPTION`.
- The auto-citation (equivalent to `citation(".", auto = TRUE)`) is always
  included under the `references` key so that both the preferred and the
  software citation are present.

## Why
A `CITATION.cff` file makes it easy for users and tools (GitHub, Zenodo,
Zotero, etc.) to cite your package correctly.

## Customisation
You can further customise the generated file by editing `CITATION.cff`
directly after this PR is merged. See the
[cffr vignette](https://docs.ropensci.org/cffr/articles/cffr.html) for
details.

Opened by the [repo-audits](https://github.com/waldronlab/repo-audits) workflow (run [#25870583138](https://github.com/waldronlab/repo-audits/actions/runs/25870583138)).
